### PR TITLE
Remove now unnecessary `Arc`s

### DIFF
--- a/compressor/src/main.rs
+++ b/compressor/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf, sync::Arc, time::Instant};
+use std::{fs::File, path::PathBuf, time::Instant};
 
 use block_compression::{
     half::f16, BC6HSettings, BC7Settings, CompressionVariant, GpuBlockCompressor,
@@ -79,7 +79,7 @@ fn main() {
     );
 }
 
-fn create_resources() -> (Arc<Device>, Arc<Queue>) {
+fn create_resources() -> (Device, Queue) {
     let instance = Instance::new(&InstanceDescriptor {
         backends: Backends::from_env().unwrap_or_default(),
         flags: InstanceFlags::from_build_config().with_env(),
@@ -113,7 +113,7 @@ fn create_resources() -> (Arc<Device>, Arc<Queue>) {
     let info = adapter.get_info();
     println!("Using backend: {:?}", info.backend);
 
-    (Arc::new(device), Arc::new(queue))
+    (device, queue)
 }
 
 fn read_image_and_create_texture(

--- a/src/block_compressor.rs
+++ b/src/block_compressor.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
+use std::{collections::HashMap, num::NonZeroU64};
 
 use bytemuck::{cast_slice, Pod, Zeroable};
 use wgpu::{
@@ -52,8 +52,8 @@ pub struct GpuBlockCompressor {
     bc7_settings_buffer: Buffer,
     bind_group_layouts: HashMap<CompressionVariant, BindGroupLayout>,
     pipelines: HashMap<CompressionVariant, ComputePipeline>,
-    device: Arc<Device>,
-    queue: Arc<Queue>,
+    device: Device,
+    queue: Queue,
     uniforms_aligned_size: usize,
     #[cfg(feature = "bc6h")]
     bc6h_aligned_size: usize,
@@ -63,7 +63,7 @@ pub struct GpuBlockCompressor {
 
 impl GpuBlockCompressor {
     /// Creates a new block compressor instance.
-    pub fn new(device: Arc<Device>, queue: Arc<Queue>) -> Self {
+    pub fn new(device: Device, queue: Queue) -> Self {
         let limits = device.limits();
 
         let alignment = limits.min_uniform_buffer_offset_alignment as usize;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use block_compression::CompressionVariant;
 use half::f16;
@@ -26,8 +26,8 @@ pub fn srgb_to_linear(srgb: u8) -> f64 {
 pub const BRICK_FILE_PATH: &str = "tests/images/brick.png";
 pub const MARBLE_FILE_PATH: &str = "tests/images/marble.png";
 
-pub fn create_wgpu_resources() -> (Arc<Device>, Arc<Queue>) {
-    static CACHE: LazyLock<(Arc<Device>, Arc<Queue>)> = LazyLock::new(|| {
+pub fn create_wgpu_resources() -> (Device, Queue) {
+    static CACHE: LazyLock<(Device, Queue)> = LazyLock::new(|| {
         let instance = Instance::new(&InstanceDescriptor {
             backends: Backends::from_env().unwrap_or_default(),
             flags: InstanceFlags::from_build_config().with_env(),
@@ -57,7 +57,7 @@ pub fn create_wgpu_resources() -> (Arc<Device>, Arc<Queue>) {
         .expect("Failed to create device");
         device.on_uncaptured_error(Box::new(error_handler));
 
-        (Arc::new(device), Arc::new(queue))
+        (device, queue)
     });
 
     CACHE.clone()


### PR DESCRIPTION
Since `wgpu` 24, most objects in the API are clonable, which removes the need for `Arc` around them.

**This is a breaking change**